### PR TITLE
enabling vTPM support for CreateHypervVms

### DIFF
--- a/Scenario-AzStackHCI/1_VMs.psd1
+++ b/Scenario-AzStackHCI/1_VMs.psd1
@@ -22,6 +22,7 @@
         vmGeneration                   = 2                                      # Gen 2 VM - you should not use Gen 1 VMs anymore
         vmProcCount                    = 6                                      # ??? Number of vCPUs
         vmAutomaticStopAction          = "ShutDown"                             # What to do when the host is shut down - saves disk space.
+        enableVMTPM                    = $true                                  # This will enable a virtual TPM to be available inside the VM (default = $false)
         vmNics                         = @{                                     # NICs of the VM  - make sure your hyper-v switch names are correct!
             "aMGMT" = @{"Switch" = "Internal"; "VLANID" = "" ; "MacAddressSpoofing" = $true }   # Don't change:    # the first NIC in alphabetical order will receive IP address as per 2_UnattendSettings.psd1
             "Comp1" = @{"Switch" = "Internal"; "VLANID" = "" ; "MacAddressSpoofing" = $true }   # Don't change:    #Get-VMNetworkAdapter -VMName $VM | Set-VMNetworkAdapter -MacAddressSpoofing On
@@ -52,6 +53,7 @@
         vmGeneration                   = 2
         vmProcCount                    = 6                                  # ???
         vmAutomaticStopAction          = "ShutDown"
+        enableVMTPM                    = $true                              
         vmNics                         = @{
             "aMGMT" = @{"Switch" = "Internal"; "VLANID" = "" ; "MacAddressSpoofing" = $true }          # the first NIC in alphabetical order will receive IP address as per 2_UnattendSettings.psd1
             "Comp1" = @{"Switch" = "Internal"; "VLANID" = "" ; "MacAddressSpoofing" = $true }         #Get-VMNetworkAdapter -VMName $VM | Set-VMNetworkAdapter -MacAddressSpoofing On} 

--- a/Scenario-AzStackHCI/CreateHypervVms.ps1
+++ b/Scenario-AzStackHCI/CreateHypervVms.ps1
@@ -308,12 +308,14 @@ foreach ($vm in $($vmConfig.GetEnumerator() | Sort-Object Name)) {
 
 
     #region enable virtual TPM if enableVMTPM = $true (1_VMs.psd1)
-    #as per https://learn.microsoft.com/en-us/azure-stack/hci/deploy/deployment-virtual
+
     if ($vm.Value.enableVMTPM) {
         "...enabling virtual TPM ..."
-        $owner = Get-HgsGuardian UntrustedGuardian
-        $kp = New-HgsKeyProtector -Owner $owner -AllowUntrustedRoot
-        Set-VMKeyProtector -VMName $vmName -KeyProtector $kp.RawData
+        #as per https://learn.microsoft.com/en-us/azure-stack/hci/deploy/deployment-virtual
+        #$owner = Get-HgsGuardian UntrustedGuardian
+        #$kp = New-HgsKeyProtector -Owner $owner -AllowUntrustedRoot
+        #Set-VMKeyProtector -VMName $vmName -KeyProtector $kp.RawData
+        Set-VMKeyProtector -VMName $vmName -NewLocalKeyProtector    #appears to require less
         Enable-VmTpm -VMName $vmName
     }
     #endregion

--- a/Scenario-AzStackHCI/CreateHypervVms.ps1
+++ b/Scenario-AzStackHCI/CreateHypervVms.ps1
@@ -306,6 +306,18 @@ foreach ($vm in $($vmConfig.GetEnumerator() | Sort-Object Name)) {
     New-Item -Path $vmDirectory -ItemType Directory -ErrorAction SilentlyContinue
     New-VM -Name $vmName -MemoryStartupBytes $vmMemory -NoVHD  -Path $vmDirectory -Generation $vmGeneration | Set-VM -ProcessorCount $vmProcCount  -AutomaticStopAction $vmAutomaticStopAction 
 
+
+    #region enable virtual TPM if enableVMTPM = $true (1_VMs.psd1)
+    #as per https://learn.microsoft.com/en-us/azure-stack/hci/deploy/deployment-virtual
+    if ($vm.Value.enableVMTPM) {
+        "...enabling virtual TPM ..."
+        $owner = Get-HgsGuardian UntrustedGuardian
+        $kp = New-HgsKeyProtector -Owner $owner -AllowUntrustedRoot
+        Set-VMKeyProtector -VMName $vmName -KeyProtector $kp.RawData
+        Enable-VmTpm -VMName $vmName
+    }
+    #endregion
+
     #region allow for nested virtualization
     if ($vm.Value.ExposeVirtualizationExtensions) {
         "...enabling nested virtualization..."

--- a/Scenario-AzStackHCI/readme.md
+++ b/Scenario-AzStackHCI/readme.md
@@ -66,7 +66,7 @@ Install-Module Az.Resources -RequiredVersion 6.12.0
 Install-Module Az.ConnectedMachine -RequiredVersion 0.5.2 
 
 #Install Arc registration script from PSGallery 
-Install-Module AzSHCI.ARCInstaller -RequiredVersion 0.2.2616.70 # avoiding registration errors in nested environments
+Install-Module AzSHCI.ARCInstaller #support for vTPM was added
 
 
 ``` 

--- a/Scenario-AzStackHCI/readme.md
+++ b/Scenario-AzStackHCI/readme.md
@@ -50,29 +50,8 @@ $deployUserPwd = "........"
 
 **[do this on every HCI node]**
 - can you ping e.g. ibm.com? -> then your nat router (on DC) works
-- install the HCI prerequisites using e.g.
-```PowerShell
-$ConfirmPreference = "HIGH"
-Write-Output "Installing PackageManagement"
-Install-Package -Name PackageManagement -MinimumVersion 1.4.8 -Force -Confirm:$false
-Write-Output "Installing PowershellGet"
-Install-Package -Name PowershellGet -Force -Verbose
-
-Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-
-#Install required PowerShell modules in your node for registration
-Install-Module Az.Accounts -RequiredVersion 2.13.2 
-Install-Module Az.Resources -RequiredVersion 6.12.0 
-Install-Module Az.ConnectedMachine -RequiredVersion 0.5.2 
-
-#Install Arc registration script from PSGallery 
-Install-Module AzSHCI.ARCInstaller #support for vTPM was added
-
-
-``` 
-
-- Disable IPv6 on all of the adapters if it was not configured by you. e.g.  
-**[do this on every HCI node]**
+- [Only install the HCI prerequisites when running older ISO files (i.e. older than 2408)](https://learn.microsoft.com/en-us/azure-stack/hci/deploy/deployment-arc-register-server-permissions?tabs=powershell)
+- Disable IPv6 on all of the adapters if it was not configured by you. e.g.:  
 ```PowerShell
 Disable-NetAdapterBinding -InterfaceAlias * -ComponentID ms_tcpip6
   

--- a/Scenario-Blueprint/1_VMs.psd1
+++ b/Scenario-Blueprint/1_VMs.psd1
@@ -8,6 +8,7 @@
         vmGeneration          = 2                                      # Gen 2 VM - you should not use Gen 1 VMs anymore
         vmProcCount           = 4                                      # ??? Number of vCPUs
         vmAutomaticStopAction = "ShutDown"                             # What to do when the host is shut down - saves disk space.
+        enableVMTPM           = $true                                  # This will enable a virtual TPM to be available inside the VM (default = $false)
         vmNics                = @{                                     # NICs of the VM  - make sure your hyper-v switch names are correct!
             "aMGMT" = @{"Switch" = "Internal"; "VLANID" = "" <#; "MacAddressSpoofing" = $true #> }   # The first NIC in alphabetical order will receive IP address as per 2_UnattendSettings.psd1 #MacAddressSpoofing is probably only required if you want to run Hyper-V inside this VM
             "Ext"   = @{"Switch" = "SetSwitch"; "VLANID" = "" }        # ??? SetSwitch -> is your external switch name on the physical host


### PR DESCRIPTION
adding vTPM support into the VM creation. It can now be configured by config file:
.
.
.
@{
    'VM0' = @{                                                          # VM0 is the first VM to be created - do not change this name
        vmName                = "Test-N1"                               # Name of the VM in Hyper-V
        vmPath                = ""
        #GoldenImagePath       = "c:\images\W2k22.vhdx"                 # If you have specific golden image just for this VM
        #ExposeVirtualizationExtensions = $true                         # Expose virtualization extensions to the VM - only required if you want to run Hyper-V inside this VM
        vmMemory              = 8GB                                    # ??? Memory in GB of the VM
        vmGeneration          = 2                                      # Gen 2 VM - you should not use Gen 1 VMs anymore
        vmProcCount           = 4                                      # ??? Number of vCPUs
        vmAutomaticStopAction = "ShutDown"                             # What to do when the host is shut down - saves disk space.
        **enableVMTPM           = $true**          